### PR TITLE
fix: remove redundant slice in fine matching for onnx inference

### DIFF
--- a/src/loftr/utils/fine_matching.py
+++ b/src/loftr/utils/fine_matching.py
@@ -66,8 +66,18 @@ class FineMatching(nn.Module):
         # mkpts0_f and mkpts1_f
         mkpts0_f = data['mkpts0_c']
         scale1 = scale * data['scale1'][data['b_ids']] if 'scale0' in data else scale
-        mkpts1_f = data['mkpts1_c'] + (coords_normed * (W // 2) * scale1)[:len(data['mconf'])]
 
+        if self.training:
+            mkpts1_f = data['mkpts1_c'] + (coords_normed * (W // 2) * scale1)[:len(data['mconf'])]
+        else:
+            
+            """
+            when run onnx inference, it will produce exception as follows:
+            Non-zero status code returned while running Add node. Name:'/fine_matching/Add_x'
+            Attempting to broadcast an axis by a dimension other than 1. 2408 by 2707
+            fix: remove redundant slice in FineMatching for ONNX export
+            """
+            mkpts1_f = data['mkpts1_c'] + coords_normed * (W // 2) * scale1
         data.update({
             "mkpts0_f": mkpts0_f,
             "mkpts1_f": mkpts1_f


### PR DESCRIPTION
### Fix: Remove redundant slice in `fine_matching.get_fine_match` to support ONNX export with dynamic match counts

#### Problem Description
When exporting LoFTR to ONNX and performing inference on image pairs with varying numbers of coarse matches, the following shape-mismatch error frequently occurs like:
```
2026-04-15 07:12:03.730711457 [E:onnxruntime:, sequential_executor.cc:572 ExecuteKernel] Non-zero status code 
 returned while running Add node. Name:'/fine_matching/Add_2' Status Message:   
/onnxruntime_src/onnxruntime/core/providers/cpu/math/element_wise_ops.h:560 void 
onnxruntime::BroadcastIterator::Append(ptrdiff_t, ptrdiff_t) axis == 1 || axis == largest was false. 
Attempting to broadcast   an axis by a dimension other than 1. 2408 by 2707  
```

The exported ONNX model works for images that produce the exact same number of matches as during export, but fails for any other image pair.

#### Root Cause Analysis
The error originates from the slice operation `[:len(data['mconf'])]` inside `FineMatching.get_fine_match`:

```python
mkpts1_f = data['mkpts1_c'] + (coords_normed * (W // 2) * scale1)[:len(data['mconf'])]
```

During training, CoarseMatching augments the coarse matches with ground-truth padding samples, causing a mismatch between the lengths of coords_normed (which includes all padded samples) and mkpts1_c (which only contains valid predictions). The slice is necessary to align them for loss computation.

During inference (i.e., model.eval()), the training branch is not executed. All coarse match tensors (b_ids, i_ids, j_ids, mkpts0_c, mkpts1_c, mconf) are derived from the same set of predicted matches and therefore have identical first-dimension lengths. The slice operation becomes redundant.

When exporting to ONNX using torch.onnx.export (tracing mode), the slice index len(data['mconf']) is evaluated once on the export-time inputs and hard-coded as a constant (e.g., 2408). For any new image pair with a different number of coarse matches (e.g., 2707), the slice produces a tensor of the wrong length, leading to a shape broadcast error in the subsequent Add node.